### PR TITLE
Remove default values from variables.tf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 infrastructure.tfvars
+.terraform*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+infrastructure.tfvars

--- a/Deployment/VMware vSphere/High Availability/README.md
+++ b/Deployment/VMware vSphere/High Availability/README.md
@@ -2,4 +2,4 @@
 
 Sample config for deploying a highly available Hammerspace cluster with
 2 Metadata nodes (Anvil) and 2 data nodes (DSX)
-Create a file called infrastructure.tfvars and populate it with the approproiate variables. Then plan with terraform plan -var-file=infrastructure.tfvars
+Create a file called infrastructure.tfvars and populate it with the appropriate variables. Then plan with terraform plan -var-file=infrastructure.tfvars

--- a/Deployment/VMware vSphere/High Availability/README.md
+++ b/Deployment/VMware vSphere/High Availability/README.md
@@ -2,3 +2,4 @@
 
 Sample config for deploying a highly available Hammerspace cluster with
 2 Metadata nodes (Anvil) and 2 data nodes (DSX)
+Create a file called infrastructure.tfvars and populate it with the approproiate variables. Then plan with terraform plan -var-file=infrastructure.tfvars

--- a/Deployment/VMware vSphere/High Availability/variables.tf
+++ b/Deployment/VMware vSphere/High Availability/variables.tf
@@ -10,8 +10,7 @@ variable "vsphere-user" {
 variable "vsphere-password" {
   type        = string
   description = "VMWare vSphere admin user password"
-# Turn on for production use. Will hide the entire custom variable entry
-#  sensitive   = true
+  sensitive   = true
 }
 
 variable "vsphere-server" {
@@ -74,7 +73,7 @@ variable "ntp-servers" {
 
 variable "dns-servers" {
   type = string
-  description = "DNS server list"
+  description = "Comma separated list of DNS servers"
 }
 
 variable "default-gateway" {
@@ -94,7 +93,7 @@ variable "cluster-name" {
 
 variable "cluster-ip" {
   type    = string
-  description = "management IP, i.e. 192.168.1.3"
+  description = "management IP, e.g. 192.168.1.3"
 }
 
 variable "hammerspace-vm-guest-id" {
@@ -145,7 +144,7 @@ variable "HA-anvil-metadatadisk" {
 # Anvil 1 settings
 variable "HA_anvil1-ip" {
   type = string
-  description = "IP/NETMASK, i.e. 192.168.1.1/22"
+  description = "IP/NETMASK, e.g. 192.168.1.1/22"
 }
 
 variable "HA-anvil1-hostname" {
@@ -157,7 +156,7 @@ variable "HA-anvil1-hostname" {
 # Anvil 2 settings
 variable "HA_anvil2-ip" {
   type = string
-  description = "IP/NETMASK, i.e. 192.168.1.2/22"
+  description = "IP/NETMASK, e.g. 192.168.1.2/22"
 }
 
 variable "HA-anvil2-hostname" {
@@ -178,8 +177,8 @@ variable "dsx-ips" {
   type        = map(any)
   description = "Map of IPs to use for the DSX nodes"
   default = {
-    "0" = "192.168.1.4/22>",
-    "1" = "192.168.1.5/22>"
+    "0" = "192.168.1.4/22",
+    "1" = "192.168.1.5/22"
   }
 }
 
@@ -219,7 +218,7 @@ variable "vm-domain" {
 
 variable "prefix" {
   type        = string
-  description = "Prefix for vm name and DSX hostname. Example: first-last-setup01"
+  description = "Prefix for VMs. Example: first-last-setup01"
 }
 
 variable "vm-folder" {

--- a/Deployment/VMware vSphere/High Availability/variables.tf
+++ b/Deployment/VMware vSphere/High Availability/variables.tf
@@ -83,7 +83,7 @@ variable "default-gateway" {
 variable "admin-password" {
   type        = string
   description = "Password for Hammerspace admin user"
-#  sensitive  = true
+  sensitive  = true
 }
 
 variable "cluster-name" {

--- a/Deployment/VMware vSphere/High Availability/variables.tf
+++ b/Deployment/VMware vSphere/High Availability/variables.tf
@@ -5,13 +5,11 @@
 variable "vsphere-user" {
   type        = string
   description = "VMWare vSphere cluster admin user"
-  default     = "<vSphere admin-level user>"
 }
 
 variable "vsphere-password" {
   type        = string
   description = "VMWare vSphere admin user password"
-  default     = "<password>"
 # Turn on for production use. Will hide the entire custom variable entry
 #  sensitive   = true
 }
@@ -19,44 +17,37 @@ variable "vsphere-password" {
 variable "vsphere-server" {
   type        = string
   description = "VMWare vCenter FQDN or IP address"
-  default     = "<vCenter address>"
 }
 
 variable "vsphere-datacenter" {
   type        = string
   description = "VMWare vSphere Datacenter"
-  default     = "<Datacenter>"
 }
 variable "vsphere-resource-pool" {
   type        = string
   description = "VMWare Resource Pool"
-  default     = "<Select a resource pool>"
 }
 
 # Not currently used for the examples
 variable "vsphere-cluster" {
   type        = string
   description = "VMWare vSphere cluster."
-  default     = "<Cluster name>"
 }
 
 variable "vsphere-host" {
   type        = string
   description = "VMWare host"
-  default     = "<ESX host to deploy on>"
 }
 
 # Optional
 variable "vsphere-template-folder" {
   type        = string
-  description = "Template folder"
-  default     = "/<Path to >/Templates"
+  description = "Template folder path."
 }
 
 variable "network-data1" {
   type        = string
-  description = "VMware production network 1"
-  default     = "<Prod/Management network name>"
+  description = "VMware Prod/Management network name"
 }
 
 # Only needs to be used when separating management traffic
@@ -69,7 +60,6 @@ variable "network-data2" {
 variable "network-ha1" {
   type        = string
   description = "VMware production HA network 1"
-  default     = "<HA network name>"
 }
 
 #=================================== #
@@ -85,30 +75,26 @@ variable "ntp-servers" {
 variable "dns-servers" {
   type = string
   description = "DNS server list"
-  default = "<Comma separated list of DNS servers>"
 }
 
 variable "default-gateway" {
   type = string
   description = "Default gateway"
-  default = "<default gateway>"
 }
 variable "admin-password" {
   type        = string
   description = "Password for Hammerspace admin user"
-  default     = "<password>"
 #  sensitive  = true
 }
 
 variable "cluster-name" {
   type        = string
   description = "Site, Cluster and SMB Server name"
-  default     = "<Hammerspace cluster name>"
 }
 
 variable "cluster-ip" {
   type    = string
-  default = "<management IP, i.e. 192.168.1.3>"
+  description = "management IP, i.e. 192.168.1.3"
 }
 
 variable "hammerspace-vm-guest-id" {
@@ -126,7 +112,6 @@ variable "hammerspace-template-name" {
 variable "hammerspace-ova-url" {
   type        = string
   description = "Hammerspace OVA url"
-  default     = "<path to Hammerspace OVA>"
 }
 
 # Please see the installation guide for sizing recommendations
@@ -160,25 +145,25 @@ variable "HA-anvil-metadatadisk" {
 # Anvil 1 settings
 variable "HA_anvil1-ip" {
   type = string
-  default = "<IP/NETMASK, i.e. 192.168.1.1/22>"
+  description = "IP/NETMASK, i.e. 192.168.1.1/22"
 }
 
 variable "HA-anvil1-hostname" {
   type = string
   description = "Hostname for Anvil 1"
-  default = "<hostname, i.e. tf-anvil1>"
+  default = "tf-anvil1"
 }
 
 # Anvil 2 settings
 variable "HA_anvil2-ip" {
   type = string
-  default = "<IP/NETMASK, i.e. 192.168.1.2/22>"
+  description = "IP/NETMASK, i.e. 192.168.1.2/22"
 }
 
 variable "HA-anvil2-hostname" {
   type = string
   description = "Hostname for Anvil 2"
-  default = "<hostname, i.e. tf-anvil2>"
+  default = "tf-anvil2"
 }
 
 # DSX
@@ -191,10 +176,10 @@ variable "dsx-count" {
 
 variable "dsx-ips" {
   type        = map(any)
-  description = "List of IPs used for the DSX nodes"
+  description = "Map of IPs to use for the DSX nodes"
   default = {
-    "0" = "<IP/NETMASK, i.e. 192.168.1.4/22>",
-    "1" = "<IP/NETMASK, i.e. 192.168.1.5/22>"
+    "0" = "192.168.1.4/22>",
+    "1" = "192.168.1.5/22>"
   }
 }
 
@@ -229,24 +214,20 @@ variable "DSX-datadisk" {
 
 variable "vm-domain" {
   type        = string
-  description = "Linux virtual machine domain name for the machine"
-  default     = "<Domain name>"
+  description = "Domain name for the VMs."
 }
 
 variable "prefix" {
   type        = string
-  description = "Prefix for vm name and DSX hostname"
-  default = "<string prefix, i.e. tf"
+  description = "Prefix for vm name and DSX hostname. Example: first-last-setup01"
 }
 
 variable "vm-folder" {
   type = string
   description = "Folder where the provisioned VM will go"
-  default = "/<ESX Folder>/"
 }
 
 variable "vm-datastore" {
   type        = string
   description = "Datastore used for all of the virtual machines"
-  default     = "<Selected datastore>"
 }

--- a/Deployment/VMware vSphere/Standalone/Large/variables.tf
+++ b/Deployment/VMware vSphere/Standalone/Large/variables.tf
@@ -142,7 +142,7 @@ variable "anvil-metadatadisk" {
 # Anvil 1 settings
 variable "anvil-ip" {
   type = string
-  description ="IP/NETMASK, e.g. 192.168.1.1/22
+  description ="IP/NETMASK, e.g. 192.168.1.1/22"
 }
 
 variable "anvil-hostname" {

--- a/Deployment/VMware vSphere/Standalone/Large/variables.tf
+++ b/Deployment/VMware vSphere/Standalone/Large/variables.tf
@@ -11,8 +11,7 @@ variable "vsphere-user" {
 variable "vsphere-password" {
   type        = string
   description = "VMWare vSphere admin user password"
-# Turn on for production use. Will hide the entire custom variable entry
-#  sensitive   = true
+  sensitive   = true
 }
 
 variable "vsphere-server" {
@@ -77,7 +76,7 @@ variable "ntp-servers" {
 
 variable "dns-servers" {
   type = string
-  description = "DNS server list"
+  description = "Comma separated list of DNS servers"
 }
 
 variable "default-gateway" {
@@ -143,12 +142,12 @@ variable "anvil-metadatadisk" {
 # Anvil 1 settings
 variable "anvil-ip" {
   type = string
-  description ="<IP/NETMASK, i.e. 192.168.1.1/22>
+  description ="IP/NETMASK, e.g. 192.168.1.1/22
 }
 
 variable "anvil-hostname" {
   type = string
-  description = "<hostname, i.e. tf-anvil1>"
+  description = "Hostname, e.g. tf-anvil1"
 }
 
 # DSX
@@ -163,7 +162,7 @@ variable "dsx-ips" {
   type        = map(any)
   description = "List of IPs used for the DSX nodes"
   default = {
-    "0" = "192.168.1.4/22>"
+    "0" = "192.168.1.4/22"
   }
 }
 
@@ -203,7 +202,7 @@ variable "vm-domain" {
 
 variable "prefix" {
   type        = string
-  description = "Prefix for vm name and DSX hostname"
+  description = "Prefix for VMs"
 }
 
 variable "vm-folder" {

--- a/Deployment/VMware vSphere/Standalone/Large/variables.tf
+++ b/Deployment/VMware vSphere/Standalone/Large/variables.tf
@@ -11,7 +11,6 @@ variable "vsphere-user" {
 variable "vsphere-password" {
   type        = string
   description = "VMWare vSphere admin user password"
-  default     = "<password>"
 # Turn on for production use. Will hide the entire custom variable entry
 #  sensitive   = true
 }
@@ -19,44 +18,37 @@ variable "vsphere-password" {
 variable "vsphere-server" {
   type        = string
   description = "VMWare vCenter FQDN or IP address"
-  default     = "<vCenter address>"
 }
 
 variable "vsphere-datacenter" {
   type        = string
   description = "VMWare vSphere Datacenter"
-  default     = "<Datacenter>"
 }
 variable "vsphere-resource-pool" {
   type        = string
   description = "VMWare Resource Pool"
-  default     = "<Select a resource pool>"
 }
 
 # Not currently used for the examples
 variable "vsphere-cluster" {
   type        = string
   description = "VMWare vSphere cluster."
-  default     = "<Cluster name>"
 }
 
 variable "vsphere-host" {
   type        = string
   description = "VMWare host"
-  default     = "<ESX host to deploy on>"
 }
 
 # Optional
 variable "vsphere-template-folder" {
   type        = string
   description = "Template folder"
-  default     = "/<Path to >/Templates"
 }
 
 variable "network-data1" {
   type        = string
   description = "VMware production network 1"
-  default     = "<Prod/Management network name>"
 }
 
 # Only needs to be used when separating management traffic
@@ -71,7 +63,6 @@ variable "network-data2" {
 variable "network-ha1" {
   type        = string
   description = "VMware production HA network 1"
-  default     = "<Prod/Management network name>"
 }
 
 #=================================== #
@@ -87,25 +78,21 @@ variable "ntp-servers" {
 variable "dns-servers" {
   type = string
   description = "DNS server list"
-  default = "<Comma separated list of DNS servers>"
 }
 
 variable "default-gateway" {
   type = string
   description = "Default gateway"
-  default = "<default gateway>"
 }
 variable "admin-password" {
   type        = string
   description = "Password for Hammerspace admin user"
-  default     = "<password>"
 #  sensitive  = true
 }
 
 variable "cluster-name" {
   type        = string
   description = "Site, Cluster and SMB Server name"
-  default     = "<Hammerspace cluster name>"
 }
 
 variable "hammerspace-vm-guest-id" {
@@ -123,7 +110,6 @@ variable "hammerspace-template-name" {
 variable "hammerspace-ova-url" {
   type        = string
   description = "Hammerspace OVA url"
-  default     = "<path to Hammerspace OVA>"
 }
 
 # Please see the installation guide for sizing recommendations
@@ -157,14 +143,12 @@ variable "anvil-metadatadisk" {
 # Anvil 1 settings
 variable "anvil-ip" {
   type = string
-  description = "Host IP address for Anvil"
-  default = "<IP/NETMASK, i.e. 192.168.1.1/22>"
+  description ="<IP/NETMASK, i.e. 192.168.1.1/22>
 }
 
 variable "anvil-hostname" {
   type = string
-  description = "Hostname for Anvil"
-  default = "<hostname, i.e. tf-anvil1>"
+  description = "<hostname, i.e. tf-anvil1>"
 }
 
 # DSX
@@ -179,7 +163,7 @@ variable "dsx-ips" {
   type        = map(any)
   description = "List of IPs used for the DSX nodes"
   default = {
-    "0" = "<IP/NETMASK, i.e. 192.168.1.4/22>"
+    "0" = "192.168.1.4/22>"
   }
 }
 
@@ -215,23 +199,19 @@ variable "DSX-datadisk" {
 variable "vm-domain" {
   type        = string
   description = "Linux virtual machine domain name for the machine"
-  default     = "<Domain name>"
 }
 
 variable "prefix" {
   type        = string
   description = "Prefix for vm name and DSX hostname"
-  default = "<string prefix, i.e. tf"
 }
 
 variable "vm-folder" {
   type = string
   description = "Folder where the provisioned VM will go"
-  default = "/<ESX Folder>/"
 }
 
 variable "vm-datastore" {
   type        = string
   description = "Datastore used for all of the virtual machines"
-  default     = "<Selected datastore>"
 }

--- a/Deployment/VMware vSphere/Standalone/Large/variables.tf
+++ b/Deployment/VMware vSphere/Standalone/Large/variables.tf
@@ -86,7 +86,7 @@ variable "default-gateway" {
 variable "admin-password" {
   type        = string
   description = "Password for Hammerspace admin user"
-#  sensitive  = true
+  sensitive  = true
 }
 
 variable "cluster-name" {

--- a/Deployment/VMware vSphere/Standalone/Medium/variables.tf
+++ b/Deployment/VMware vSphere/Standalone/Medium/variables.tf
@@ -10,8 +10,7 @@ variable "vsphere-user" {
 variable "vsphere-password" {
   type        = string
   description = "VMWare vSphere admin user password"
-# Turn on for production use. Will hide the entire custom variable entry
-#  sensitive   = true
+  sensitive   = true
 }
 
 variable "vsphere-server" {
@@ -76,7 +75,7 @@ variable "ntp-servers" {
 
 variable "dns-servers" {
   type = string
-  description = "DNS server list"
+  description = "Comma separated list of DNS servers"
 }
 
 variable "default-gateway" {
@@ -142,7 +141,7 @@ variable "anvil-metadatadisk" {
 # Anvil 1 settings
 variable "anvil-ip" {
   type = string
-  description = "<IP/NETMASK, i.e. 192.168.1.1/22>"
+  description = "IP/NETMASK, e.g. 192.168.1.1/22"
 }
 
 variable "anvil-hostname" {
@@ -162,7 +161,7 @@ variable "dsx-ips" {
   type        = map(any)
   description = "List of IPs used for the DSX nodes"
   default = {
-    "0" = "<IP/NETMASK, i.e. 192.168.1.4/22>"
+    "0" = "IP/NETMASK, e.g. 192.168.1.4/22"
   }
 }
 
@@ -202,7 +201,7 @@ variable "vm-domain" {
 
 variable "prefix" {
   type        = string
-  description = "Prefix for vm name and DSX hostname"
+  description = "Prefix for VMs."
 }
 
 variable "vm-folder" {

--- a/Deployment/VMware vSphere/Standalone/Medium/variables.tf
+++ b/Deployment/VMware vSphere/Standalone/Medium/variables.tf
@@ -5,13 +5,11 @@
 variable "vsphere-user" {
   type        = string
   description = "VMWare vSphere cluster admin user"
-  default     = "<vSphere admin-level user>"
 }
 
 variable "vsphere-password" {
   type        = string
   description = "VMWare vSphere admin user password"
-  default     = "<password>"
 # Turn on for production use. Will hide the entire custom variable entry
 #  sensitive   = true
 }
@@ -19,44 +17,37 @@ variable "vsphere-password" {
 variable "vsphere-server" {
   type        = string
   description = "VMWare vCenter FQDN or IP address"
-  default     = "<vCenter address>"
 }
 
 variable "vsphere-datacenter" {
   type        = string
   description = "VMWare vSphere Datacenter"
-  default     = "<Datacenter>"
 }
 variable "vsphere-resource-pool" {
   type        = string
   description = "VMWare Resource Pool"
-  default     = "<Select a resource pool>"
 }
 
 # Not currently used for the examples
 variable "vsphere-cluster" {
   type        = string
   description = "VMWare vSphere cluster."
-  default     = "<Cluster name>"
 }
 
 variable "vsphere-host" {
   type        = string
   description = "VMWare host"
-  default     = "<ESX host to deploy on>"
 }
 
 # Optional
 variable "vsphere-template-folder" {
   type        = string
   description = "Template folder"
-  default     = "/<Path to >/Templates"
 }
 
 variable "network-data1" {
   type        = string
   description = "VMware production network 1"
-  default     = "<Prod/Management network name>"
 }
 
 # Only needs to be used when separating management traffic
@@ -71,7 +62,6 @@ variable "network-data2" {
 variable "network-ha1" {
   type        = string
   description = "VMware production HA network 1"
-  default     = "<Prod/Management network name>"
 }
 
 #=================================== #
@@ -87,25 +77,21 @@ variable "ntp-servers" {
 variable "dns-servers" {
   type = string
   description = "DNS server list"
-  default = "<Comma separated list of DNS servers>"
 }
 
 variable "default-gateway" {
   type = string
   description = "Default gateway"
-  default = "<default gateway>"
 }
 variable "admin-password" {
   type        = string
   description = "Password for Hammerspace admin user"
-  default     = "<password>"
 #  sensitive  = true
 }
 
 variable "cluster-name" {
   type        = string
   description = "Site, Cluster and SMB Server name"
-  default     = "<Hammerspace cluster name>"
 }
 
 variable "hammerspace-vm-guest-id" {
@@ -123,7 +109,6 @@ variable "hammerspace-template-name" {
 variable "hammerspace-ova-url" {
   type        = string
   description = "Hammerspace OVA url"
-  default     = "<path to Hammerspace OVA>"
 }
 
 # Please see the installation guide for sizing recommendations
@@ -157,14 +142,12 @@ variable "anvil-metadatadisk" {
 # Anvil 1 settings
 variable "anvil-ip" {
   type = string
-  description = "Host IP address for Anvil"
-  default = "<IP/NETMASK, i.e. 192.168.1.1/22>"
+  description = "<IP/NETMASK, i.e. 192.168.1.1/22>"
 }
 
 variable "anvil-hostname" {
   type = string
   description = "Hostname for Anvil"
-  default = "<hostname, i.e. tf-anvil1>"
 }
 
 # DSX
@@ -215,23 +198,19 @@ variable "DSX-datadisk" {
 variable "vm-domain" {
   type        = string
   description = "Linux virtual machine domain name for the machine"
-  default     = "<Domain name>"
 }
 
 variable "prefix" {
   type        = string
   description = "Prefix for vm name and DSX hostname"
-  default = "<string prefix, i.e. tf"
 }
 
 variable "vm-folder" {
   type = string
   description = "Folder where the provisioned VM will go"
-  default = "/<ESX Folder>/"
 }
 
 variable "vm-datastore" {
   type        = string
   description = "Datastore used for all of the virtual machines"
-  default     = "<Selected datastore>"
 }

--- a/Deployment/VMware vSphere/Standalone/Medium/variables.tf
+++ b/Deployment/VMware vSphere/Standalone/Medium/variables.tf
@@ -85,7 +85,7 @@ variable "default-gateway" {
 variable "admin-password" {
   type        = string
   description = "Password for Hammerspace admin user"
-#  sensitive  = true
+  sensitive  = true
 }
 
 variable "cluster-name" {

--- a/Deployment/VMware vSphere/Standalone/README.md
+++ b/Deployment/VMware vSphere/Standalone/README.md
@@ -2,4 +2,4 @@
 
 Sample config for deploying a standalone Hammerspace with
 1 Metadata node (Anvil) and 1 data nodes (DSX)
-Create a file called infrastructure.tfvars and populate it with the approproiate variables. Then plan with terraform plan -var-file=infrastructure.tfvars
+Create a file called infrastructure.tfvars and populate it with the appropriate variables. Then plan with terraform plan -var-file=infrastructure.tfvars

--- a/Deployment/VMware vSphere/Standalone/README.md
+++ b/Deployment/VMware vSphere/Standalone/README.md
@@ -2,3 +2,4 @@
 
 Sample config for deploying a standalone Hammerspace with
 1 Metadata node (Anvil) and 1 data nodes (DSX)
+Create a file called infrastructure.tfvars and populate it with the approproiate variables. Then plan with terraform plan -var-file=infrastructure.tfvars

--- a/Deployment/VMware vSphere/Standalone/Small/variables.tf
+++ b/Deployment/VMware vSphere/Standalone/Small/variables.tf
@@ -10,8 +10,7 @@ variable "vsphere-user" {
 variable "vsphere-password" {
   type        = string
   description = "VMWare vSphere admin user password"
-# Turn on for production use. Will hide the entire custom variable entry
-#  sensitive   = true
+  sensitive   = true
 }
 
 variable "vsphere-server" {
@@ -76,7 +75,7 @@ variable "ntp-servers" {
 
 variable "dns-servers" {
   type = string
-  description = "DNS server list"
+  description = "Comma separated list of DNS servers"
 }
 
 variable "default-gateway" {
@@ -142,7 +141,7 @@ variable "anvil-metadatadisk" {
 # Anvil 1 settings
 variable "anvil-ip" {
   type = string
-  description = "<IP/NETMASK, i.e. 192.168.1.1/22>"
+  description = "IP/NETMASK, e.g. 192.168.1.1/22"
 }
 
 variable "anvil-hostname" {
@@ -162,7 +161,7 @@ variable "dsx-ips" {
   type        = map(any)
   description = "List of IPs used for the DSX nodes"
   default = {
-    "0" = "<IP/NETMASK, i.e. 192.168.1.4/22>"
+    "0" = "IP/NETMASK, e.g. 192.168.1.4/22"
   }
 }
 
@@ -202,7 +201,7 @@ variable "vm-domain" {
 
 variable "prefix" {
   type        = string
-  description = "Prefix for vm name and DSX hostname"
+  description = "Prefix for VMs"
 }
 
 variable "vm-folder" {

--- a/Deployment/VMware vSphere/Standalone/Small/variables.tf
+++ b/Deployment/VMware vSphere/Standalone/Small/variables.tf
@@ -5,13 +5,11 @@
 variable "vsphere-user" {
   type        = string
   description = "VMWare vSphere cluster admin user"
-  default     = "<vSphere admin-level user>"
 }
 
 variable "vsphere-password" {
   type        = string
   description = "VMWare vSphere admin user password"
-  default     = "<password>"
 # Turn on for production use. Will hide the entire custom variable entry
 #  sensitive   = true
 }
@@ -19,44 +17,37 @@ variable "vsphere-password" {
 variable "vsphere-server" {
   type        = string
   description = "VMWare vCenter FQDN or IP address"
-  default     = "<vCenter address>"
 }
 
 variable "vsphere-datacenter" {
   type        = string
   description = "VMWare vSphere Datacenter"
-  default     = "<Datacenter>"
 }
 variable "vsphere-resource-pool" {
   type        = string
   description = "VMWare Resource Pool"
-  default     = "<Select a resource pool>"
 }
 
 # Not currently used for the examples
 variable "vsphere-cluster" {
   type        = string
   description = "VMWare vSphere cluster."
-  default     = "<Cluster name>"
 }
 
 variable "vsphere-host" {
   type        = string
   description = "VMWare host"
-  default     = "<ESX host to deploy on>"
 }
 
 # Optional
 variable "vsphere-template-folder" {
   type        = string
   description = "Template folder"
-  default     = "/<Path to >/Templates"
 }
 
 variable "network-data1" {
   type        = string
   description = "VMware production network 1"
-  default     = "<Prod/Management network name>"
 }
 
 # Only needs to be used when separating management traffic
@@ -71,7 +62,6 @@ variable "network-data2" {
 variable "network-ha1" {
   type        = string
   description = "VMware production HA network 1"
-  default     = "<Prod/Management network name>"
 }
 
 #=================================== #
@@ -87,25 +77,21 @@ variable "ntp-servers" {
 variable "dns-servers" {
   type = string
   description = "DNS server list"
-  default = "<Comma separated list of DNS servers>"
 }
 
 variable "default-gateway" {
   type = string
   description = "Default gateway"
-  default = "<default gateway>"
 }
 variable "admin-password" {
   type        = string
   description = "Password for Hammerspace admin user"
-  default     = "<password>"
 #  sensitive  = true
 }
 
 variable "cluster-name" {
   type        = string
   description = "Site, Cluster and SMB Server name"
-  default     = "<Hammerspace cluster name>"
 }
 
 variable "hammerspace-vm-guest-id" {
@@ -123,7 +109,6 @@ variable "hammerspace-template-name" {
 variable "hammerspace-ova-url" {
   type        = string
   description = "Hammerspace OVA url"
-  default     = "<path to Hammerspace OVA>"
 }
 
 # Please see the installation guide for sizing recommendations
@@ -157,14 +142,12 @@ variable "anvil-metadatadisk" {
 # Anvil 1 settings
 variable "anvil-ip" {
   type = string
-  description = "Host IP address for Anvil"
-  default = "<IP/NETMASK, i.e. 192.168.1.1/22>"
+  description = "<IP/NETMASK, i.e. 192.168.1.1/22>"
 }
 
 variable "anvil-hostname" {
   type = string
   description = "Hostname for Anvil"
-  default = "<hostname, i.e. tf-anvil1>"
 }
 
 # DSX
@@ -215,23 +198,19 @@ variable "DSX-datadisk" {
 variable "vm-domain" {
   type        = string
   description = "Linux virtual machine domain name for the machine"
-  default     = "<Domain name>"
 }
 
 variable "prefix" {
   type        = string
   description = "Prefix for vm name and DSX hostname"
-  default = "<string prefix, i.e. tf"
 }
 
 variable "vm-folder" {
   type = string
   description = "Folder where the provisioned VM will go"
-  default = "/<ESX Folder>/"
 }
 
 variable "vm-datastore" {
   type        = string
   description = "Datastore used for all of the virtual machines"
-  default     = "<Selected datastore>"
 }

--- a/Deployment/VMware vSphere/Standalone/Small/variables.tf
+++ b/Deployment/VMware vSphere/Standalone/Small/variables.tf
@@ -85,7 +85,7 @@ variable "default-gateway" {
 variable "admin-password" {
   type        = string
   description = "Password for Hammerspace admin user"
-#  sensitive  = true
+  sensitive  = true
 }
 
 variable "cluster-name" {

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ by Hammerspace.
 
 [Standalone](Deployment/VMware%20vSphere/Standalone/) deployment
 
+Be sure to create a variables file infrastructure.tfvars with the details for your infrastructure
+
 For deployments in Azure, please see the following link:
 
 https://github.com/Azure/Avere/tree/main/src/terraform/examples/hammerspace

--- a/example.infrastructure.tfvars
+++ b/example.infrastructure.tfvars
@@ -1,0 +1,50 @@
+# vCenter infrastructure description
+vsphere-server   = "vcenter.example.com"
+vsphere-user     = "user@vsphere.local"
+vsphere-password = ""
+
+vsphere-datacenter      = "example_datacenter"
+vsphere-host            = "esxi-example-host01"
+vsphere-template-folder = "/path/to/templates"
+vsphere-cluster         = "example-cluster"
+vsphere-resource-pool   = "example-resource-pool"
+
+vm-datastore = "esxi-example-host01-disk01"
+
+network-data1 = "VLAN01"
+network-ha1   = "VLAN02"
+
+ntp-servers     = "10.20.30.40"
+dns-servers     = "10.20.30.41"
+default-gateway = "10.20.10.1"
+
+# Local variables
+prefix               = "example-vm-prefix"
+vm-folder            = "path/to/folder"
+hammerspace-ova-url  = "https://example.server.com/hammerspace-1.2.3-456.ova"
+hammerspace-ova-path = "./hammerspace-1.2.3-456.ova"
+
+# Hammerspace Cluster variables
+admin-password     = "" # Hammerspace cluster admin password
+HA_anvil1-ip       = "10.20.30.45/24"
+HA-anvil1-hostname = "example-anvil01"
+
+HA_anvil2-ip       = "10.20.30.46/24"
+HA-anvil2-hostname = "example-anvil02"
+
+dsx-count = 3
+dsx-ips = {
+  "0" = "10.20.30.47/24",
+  "1" = "10.20.30.48/24",
+  "2" = "10.20.30.49/24"
+}
+DSX-cpu   = 4
+DSX-mem   = 12288
+vm-domain = "example.local"
+
+cluster-name = "example-cluster-name"
+cluster-ip   = "10.20.30.50"
+
+# VM hardware variables
+HA-anvil-cpu = 6
+HA-anvil-mem = 12288


### PR DESCRIPTION
This pull request removes the default values from variables.tf. This de-incentivizes users from adding their potentially sensitive values to the version controlled variables.tf, and instead put them in the git ignored infrastructure.tfvars. 

The purpose of default values in terraform is to provide a workable default value that a user may or may not want/need to edit. The current default values are more like a description, and are not workable default values. For example, providing a default value for the anvil-bootdisk size makes sense, as there should be a default a user can run with. However, a default for the password, vCenter address, or anvil IP addresses would not be necessary.